### PR TITLE
Fix routing issues on login modal

### DIFF
--- a/ldregistry/config/app.conf
+++ b/ldregistry/config/app.conf
@@ -62,7 +62,7 @@ config.oauth2        = $oauth2
 
 # The Registry configuration itself
 registry             = com.epimorphics.registry.core.Registry
-registry.baseUri     = http://codes.wmo.int/
+registry.baseUri     = http://codes.wmo.int
 registry.store       = $storeapi
 registry.cacheSize   = 100
 registry.pageSize    = 9000

--- a/ldregistry/templates/nav/_menu-advanced.vm
+++ b/ldregistry/templates/nav/_menu-advanced.vm
@@ -4,7 +4,7 @@
     <a href="#" class="dropdown-toggle" data-toggle="dropdown">$msg['nav.advanced.label']<b class="caret"></b></a>
     <ul class="dropdown-menu">
         #if( ! $subject.isAuthenticated() )
-            <li><a href="$absoluteRoot/ui/login?return=$absoluteRoot/$uri">$msg['login.button']</a></li>
+            <li><a href="$absoluteRoot/ui/login?return=/$uri">$msg['login.button']</a></li>
         #end
 
         #if( $subject.isAuthenticated() )


### PR DESCRIPTION
Resolves issue where user is redirected to a 404 page after login. User was getting sent to http://codes.wmo.int/http://codes.wmo.int (yes, twice).

Code was previously only updated in MO instance but now matches MO instance config/template.