### PR TITLE
JAG-59 Remove hard coded WMO URL from sparql query form

### DIFF
--- a/ldregistry/templates/sparql-form.vm
+++ b/ldregistry/templates/sparql-form.vm
@@ -1,11 +1,12 @@
 #set($pageTitle=$msg['sparql.title'])
 #set($extraCSS="qonsole.css,codemirror.css")
 #set($nav="sparql")
+#set($baseURI=$registry.baseURI)
 #parse("structure/_preamble.vm")
 
     <!-- This link provides CORS support in IE8+ -->
     <!--[if lt IE 10]>
-      <script src="js/lib/jquery.xdomainrequest.js"></script>
+      <script src="js/qlib/jquery.xdomainrequest.js"></script>
     <![endif]-->
 
     <div class="qonsole">
@@ -32,6 +33,7 @@
         </div>
         <div class="query-chrome">
           <form class="form-inline">
+            <input type="hidden" id="baseUri" value="$baseURI">
 
             <div class="form-group">
               <label for="sparqlEndpoint">$msg['sparql.endpoint.label']</label>

--- a/ldregistry/ui/assets/js/app/qconfig.js
+++ b/ldregistry/ui/assets/js/app/qconfig.js
@@ -1,5 +1,6 @@
       // configuration
-      var config = {
+      let baseURI = $("#baseUri").val();
+      let config = {
         endpoints: {
           "default": "/system/query",
         },
@@ -27,7 +28,7 @@
           } ,
           { "name": "List items in a register",
             "query": "select *\nwhere {\n" +
-                     "  ?item reg:register <http://codes.wmo.int/system/prefixes>;\n" +
+                     "  ?item reg:register <" + baseURI + "/system/prefixes>;\n" +
                      "        version:currentVersion ?itemVer.\n}"
           }
         ]


### PR DESCRIPTION
Jira: [JAG-59](https://metoffice.atlassian.net/browse/JAG-59)
Description: _Remove hard-coded WMO URL from SPARQL query form to match (now fixed) MO instance._

Tasks:
- [x] Created HTML hidden field from velocity variable and read via JavaScript.


[JAG-59]: https://metoffice.atlassian.net/browse/JAG-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ