### PR TITLE
[WIP] JAG-211 Update WMO homepage category filter

### DIFF
--- a/ldregistry/templates/main/_page-category.vm
+++ b/ldregistry/templates/main/_page-category.vm
@@ -2,7 +2,7 @@
   <h1>$msg['register.list.heading']</h1>
   #set($base="${root}/")
   #if(!$state)
-    #set($state="category=<http://codes.wmo.int/structure/category/WMO-I.2>")
+    #set($state="category=<http://codes.wmo.int/structure/category/home>")
   #end
 
   #set($fr=$registry.facetService.query($state, $language))


### PR DESCRIPTION
Jira: [JAG-211](https://metoffice.atlassian.net/browse/JAG-211)
Description: Currently there is a hard coded reference to filter registers on the home page based on the register category (reg:Category) being equal to [http://codes.wmo.int/structure/category/WMO-I.2](http://codes.wmo.int/structure/category/WMO-I.2%E2%80%9C). Some registers incorrectly have this category assigned just so they can appear on the home page, which is not ideal

We would like to update this filter to reference registers with a reg:Category of [http://codes.wmo.int/structure/category/home](http://codes.wmo.int/structure/category/home%E2%80%9D) instead.

Tasks:
- [x] Change hard coded category reference
- [ ] Modify category tags on affected registers
- [ ] Test


[JAG-211]: https://metoffice.atlassian.net/browse/JAG-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ