### PR TITLE
JAG-77 Fix non-operational website banner logic/appearance

### DIFF
--- a/ldregistry/config/app.conf
+++ b/ldregistry/config/app.conf
@@ -72,6 +72,6 @@ registry.bootSpec    = /opt/ldregistry/config/root-register.ttl|{webapp}/WEB-INF
 registry.systemBoot  = /opt/ldregistry/boot
 registry.facetService = $facetService
 registry.backupDir   = /var/opt/ldregistry/backup
-registry.redirectToHttpsOnLogin = false
+registry.redirectToHttpsOnLogin = true
 registry.configExtensions = $config
 registry.requestLogger = $requestLogger

--- a/ldregistry/templates/nav/_navbar.vm
+++ b/ldregistry/templates/nav/_navbar.vm
@@ -66,6 +66,7 @@
             </div>
         </div>
     </div>
+    <p>Request URL = $request.getRequestURL().toString()</p>
     #if(!$request.getRequestURL().toString().equals("https://ci.codes.wmo.int/"))
         <div class="non-operational-banner">This is a test website – some features and links may not work, and data may be incorrect.</div>
     #end

--- a/ldregistry/templates/nav/_navbar.vm
+++ b/ldregistry/templates/nav/_navbar.vm
@@ -66,11 +66,7 @@
             </div>
         </div>
     </div>
-    <p>Server name = $request.getServerName()</p>
-    <p>Request URL = $request.getRequestURL().toString()</p>
-    #if(!$request.getRequestURL().toString().equals("https://ci.codes.wmo.int/"))
-        <div class="non-operational-banner">This is a test website – some features and links may not work, and data may be incorrect.</div>
-    #end
+
 </nav>
 
 #if($subject.isAuthenticated())

--- a/ldregistry/templates/nav/_navbar.vm
+++ b/ldregistry/templates/nav/_navbar.vm
@@ -66,6 +66,7 @@
             </div>
         </div>
     </div>
+    <p>Root = $root</p>
     <p>Request URL = $request.getRequestURL().toString()</p>
     #if(!$request.getRequestURL().toString().equals("https://ci.codes.wmo.int/"))
         <div class="non-operational-banner">This is a test website – some features and links may not work, and data may be incorrect.</div>

--- a/ldregistry/templates/nav/_navbar.vm
+++ b/ldregistry/templates/nav/_navbar.vm
@@ -66,7 +66,7 @@
             </div>
         </div>
     </div>
-    #if(!$request.getRequestURL().toString().equals("https://codes.wmo.int/"))
+    #if(!$request.getRequestURL().toString().equals("https://ci.codes.wmo.int/"))
         <div class="non-operational-banner">This is a test website – some features and links may not work, and data may be incorrect.</div>
     #end
 </nav>
@@ -74,4 +74,3 @@
 #if($subject.isAuthenticated())
     #parse( "actions/_logout-dialog.vm" )
 #end
-

--- a/ldregistry/templates/nav/_navbar.vm
+++ b/ldregistry/templates/nav/_navbar.vm
@@ -66,7 +66,7 @@
             </div>
         </div>
     </div>
-    <p>Root = $root</p>
+    <p>Server name = $request.getServerName()</p>
     <p>Request URL = $request.getRequestURL().toString()</p>
     #if(!$request.getRequestURL().toString().equals("https://ci.codes.wmo.int/"))
         <div class="non-operational-banner">This is a test website – some features and links may not work, and data may be incorrect.</div>

--- a/ldregistry/templates/structure/_service-bar.vm
+++ b/ldregistry/templates/structure/_service-bar.vm
@@ -7,7 +7,7 @@
    ##     </span>
    ##     $msg.get('service.beta.description', 'TBD')
    ## </div>
-#if(!$request.getServerName().equals("ci.codes.wmo.int"))
+#if(!$request.getServerName().equals("codes.wmo.int"))
     <div class="row">
         <div class="non-operational-banner">This is a test website – some features and links may not work, and data may be incorrect.</div>
     </div>

--- a/ldregistry/templates/structure/_service-bar.vm
+++ b/ldregistry/templates/structure/_service-bar.vm
@@ -7,3 +7,8 @@
    ##     </span>
    ##     $msg.get('service.beta.description', 'TBD')
    ## </div>
+#if(!$request.getServerName().equals("ci.codes.wmo.int"))
+    <div class="row">
+        <div class="non-operational-banner">This is a test website – some features and links may not work, and data may be incorrect.</div>
+    </div>
+#end

--- a/ldregistry/ui/assets/css/ui.css
+++ b/ldregistry/ui/assets/css/ui.css
@@ -202,9 +202,11 @@ td.align-right {
 }
 
 .non-operational-banner {
-    width: 100%;
-    background-color: #ff7e00;
-    font-size:28px;
-    text-align:center;
-    font-family: Arial, Helvetica, sans-serif;
+  background-color: #ff7e00;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 16px;
+  margin-bottom: 10px;
+  padding: 10px;
+  text-align: center;
+  width: 100%;
 }


### PR DESCRIPTION
Jira: [JAG-77](https://metoffice.atlassian.net/browse/JAG-77)
Description: _Testing the non-operational website banner failed as the logic was checking a HTTP link against a HTTPS one. Use the host name instead of the full URL._

Tasks:
- [x] Tidy up banner appearance and move code to Service Bar template file.
- [x] Fix the logic to use server name not URL
- [x] Ad hoc fix to ensure login page redirects to a HTTPS page not HTTP identified while investigating protocol difference.

With banner: https://mike.dev.codes.wmo.int/
Without banner: https://ci.codes.wmo.int/

New banner appearance:

![image](https://github.com/MetOffice/dm-dps-wmo-codes-registry/assets/21951921/5a50c96d-16c5-40bb-b601-dc3291d3695c)


[JAG-77]: https://metoffice.atlassian.net/browse/JAG-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ